### PR TITLE
Fixing tooltip showing location instead of state

### DIFF
--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -76,7 +76,7 @@ function getLocationFromItem($item) {
 
 function getStatusFromItem($item) {
    $states_id = $item->fields["states_id"];
-   $states_tmp = new Location();
+   $states_tmp = new State();
    $states_tmp->getFromDB($states_id);
    return $states_tmp->getName();
 }

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -52,11 +52,9 @@ function getToolTipforItem($item) {
       $manufacturer = getManufacturerFromItem($item);
       $toolTip .= "<br><b>" . __('Manufacturer') . " & " . __('Model') . " : </b>" . $manufacturer . " | " . $typemodel;
    }
-   if ($show_status) {
-      if ($item->isField("states_id")) {
-         $status = getStatusFromItem($item);
-         $toolTip .= "<br><b>" . __('Status')  . " : </b>" . $status;
-      }
+   if ($show_status && $item->isField("states_id")) {
+      $status = getStatusFromItem($item);
+      $toolTip .= "<br><b>" . __('Status')  . " : </b>" . $status;
    }
    $tooltip = nl2br($toolTip);
    Html::showToolTip($tooltip, null);

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -53,8 +53,10 @@ function getToolTipforItem($item) {
       $toolTip .= "<br><b>" . __('Manufacturer') . " & " . __('Model') . " : </b>" . $manufacturer . " | " . $typemodel;
    }
    if ($show_status) {
-      $status = getStatusFromItem($item);
-      $toolTip .= "<br><b>" . __('Status')  . " : </b>" . $status;
+      if ($item->isField("states_id")) {
+         $status = getStatusFromItem($item);
+         $toolTip .= "<br><b>" . __('Status')  . " : </b>" . $status;
+      }
    }
    $tooltip = nl2br($toolTip);
    Html::showToolTip($tooltip, null);


### PR DESCRIPTION
The tooltip was recovering a Location instead of a state, resulting in the wrong information being displayed