### PR TITLE
Added: option to enable access to profiles with the read and make_reservation rights

### DIFF
--- a/front/config.form.php
+++ b/front/config.form.php
@@ -22,6 +22,9 @@ if ($plugin->isActivated("reservation")) {
     if (isset($_POST["conflict_action"])) {
         $PluginReservationConfig->setConfigurationValue("conflict_action", $_POST["conflict_action"]);
     }
+    if (isset($_POST["read_make_access"])) {
+        $PluginReservationConfig->setConfigurationValue("read_make_access", $_POST["read_make_access"]);
+    }    
     if (isset($_POST["checkin"])) {
         $PluginReservationConfig->setConfigurationValue("checkin", $_POST["checkin"]);
         $PluginReservationConfig->setConfigurationValue("checkin_timeout", $_POST["checkin_timeout"]);

--- a/front/menu.php
+++ b/front/menu.php
@@ -18,7 +18,17 @@ if (!$plugin->isInstalled('reservation') || !$plugin->isActivated('reservation')
     return Html::displayNotFoundError();    
 }
 
-Session::checkRightsOr("reservation", [CREATE, UPDATE, DELETE]);
+
+// Check if the user is allowed to go here
+$config = new PluginReservationConfig();
+$read_make_access = $config->getConfigurationValue("read_make_access");
+$access = [CREATE, UPDATE, DELETE];
+
+if($read_make_access) {
+   $access = [READ, ReservationItem::RESERVEANITEM, CREATE, UPDATE, DELETE];
+}
+
+Session::checkRightsOr("reservation", $access);
 
 global $CFG_GLPI;
 $form_dates = [];

--- a/front/multiedit.form.php
+++ b/front/multiedit.form.php
@@ -11,7 +11,16 @@ $plugin = new Plugin();
 if ($plugin->isActivated("reservation")) {
     $PluginReservationMultiEdit = new PluginReservationMultiEdit();
 
-    Session::checkRightsOr('reservation', [CREATE, UPDATE, DELETE, PURGE]);
+    // Check if the user is allowed to go here
+    $config = new PluginReservationConfig();
+    $read_make_access = $config->getConfigurationValue("read_make_access");
+    $access = [CREATE, UPDATE, DELETE, PURGE];
+    
+    if($read_make_access) {
+        $access = [READ, CREATE, UPDATE, DELETE, PURGE];
+    }
+
+    Session::checkRightsOr('reservation', $access);
 
     Html::header(PluginReservationMultiEdit::getTypeName(2), $_SERVER['PHP_SELF'], "plugins", "pluginreservationmenu", "reservation");
 

--- a/front/query.php
+++ b/front/query.php
@@ -12,7 +12,17 @@ if (!$plugin->isInstalled('reservation') || !$plugin->isActivated('reservation')
     return http_response_code(401);
 }
 
-if (!Session::haveRightsOr("reservation", [CREATE, UPDATE, DELETE])) {
+
+// Check if the user is allowed to go here
+$config = new PluginReservationConfig();
+$read_make_access = $config->getConfigurationValue("read_make_access");
+$access = [CREATE, UPDATE, DELETE];
+    
+if($read_make_access) {
+    $access = [READ, ReservationItem::RESERVEANITEM, CREATE, UPDATE, DELETE, PURGE];
+}
+
+if (!Session::haveRightsOr("reservation", $access)) {
     return http_response_code(401);
 }
 

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -177,6 +177,16 @@ class PluginReservationConfig extends CommonDBTM
         echo "</td>";
         echo "</tr>";
 
+        // read and make access
+        $read_make_access = $this->getConfigurationValue("read_make_access", 0);
+        echo '<tr class="tab_bg_2">';
+        echo "<input type=\"hidden\" name=\"read_make_access\" value=\"0\">";
+        echo "<td style=\"padding-left:20px;\">";
+        echo "<input type=\"checkbox\" name=\"read_make_access\" value=\"1\" " . ($read_make_access ? 'checked' : '') . "> ";
+        echo __('Enable access for users with Read and Make a reservation right', 'reservation') . "</td>";
+        echo '</tr>';
+
+
         // checkin
         $checkin = $this->getConfigurationValue("checkin", 0);
         $checkin_timeout = $this->getConfigurationValue("checkin_timeout", 1);


### PR DESCRIPTION
The goal of this PR is to add an option in the plugin configuration so that users with limited rights on reservation (read or make a reservation) can use the plugin.

Turning (or keeping) this option off will only allow admins (with create/update/delete/purge) to use the plugin as it is originaly intended