### PR TITLE
Option to limit checkin out edit

### DIFF
--- a/front/config.form.php
+++ b/front/config.form.php
@@ -24,6 +24,9 @@ if ($plugin->isActivated("reservation")) {
     }
     if (isset($_POST["read_make_access"])) {
         $PluginReservationConfig->setConfigurationValue("read_make_access", $_POST["read_make_access"]);
+    }
+    if (isset($_POST["only_ckeckin_own"])) {
+        $PluginReservationConfig->setConfigurationValue("only_ckeckin_own", $_POST["only_ckeckin_own"]);
     }    
     if (isset($_POST["checkin"])) {
         $PluginReservationConfig->setConfigurationValue("checkin", $_POST["checkin"]);

--- a/front/config.form.php
+++ b/front/config.form.php
@@ -22,6 +22,9 @@ if ($plugin->isActivated("reservation")) {
     if (isset($_POST["conflict_action"])) {
         $PluginReservationConfig->setConfigurationValue("conflict_action", $_POST["conflict_action"]);
     }
+    if (isset($_POST["read_make_access"])) {
+        $PluginReservationConfig->setConfigurationValue("read_make_access", $_POST["read_make_access"]);
+    }    
     if (isset($_POST["checkin"])) {
         $PluginReservationConfig->setConfigurationValue("checkin", $_POST["checkin"]);
         $PluginReservationConfig->setConfigurationValue("checkin_timeout", $_POST["checkin_timeout"]);

--- a/front/menu.php
+++ b/front/menu.php
@@ -18,7 +18,17 @@ if (!$plugin->isInstalled('reservation') || !$plugin->isActivated('reservation')
     return Html::displayNotFoundError();    
 }
 
-Session::checkRightsOr("reservation", [CREATE, UPDATE, DELETE]);
+
+// Check if the user is allowed to go here
+$config = new PluginReservationConfig();
+$read_make_access = $config->getConfigurationValue("read_make_access");
+$access = [CREATE, UPDATE, DELETE];
+
+if($read_make_access) {
+   $access = [READ, ReservationItem::RESERVEANITEM, CREATE, UPDATE, DELETE];
+}
+
+Session::checkRightsOr("reservation", $access);
 
 global $CFG_GLPI;
 $form_dates = [];

--- a/front/multiedit.form.php
+++ b/front/multiedit.form.php
@@ -11,7 +11,16 @@ $plugin = new Plugin();
 if ($plugin->isActivated("reservation")) {
     $PluginReservationMultiEdit = new PluginReservationMultiEdit();
 
-    Session::checkRightsOr('reservation', [CREATE, UPDATE, DELETE, PURGE]);
+    // Check if the user is allowed to go here
+    $config = new PluginReservationConfig();
+    $read_make_access = $config->getConfigurationValue("read_make_access");
+    $access = [CREATE, UPDATE, DELETE, PURGE];
+    
+    if($read_make_access) {
+        $access = [READ, CREATE, UPDATE, DELETE, PURGE];
+    }
+
+    Session::checkRightsOr('reservation', $access);
 
     Html::header(PluginReservationMultiEdit::getTypeName(2), $_SERVER['PHP_SELF'], "plugins", "pluginreservationmenu", "reservation");
 

--- a/front/query.php
+++ b/front/query.php
@@ -12,7 +12,17 @@ if (!$plugin->isInstalled('reservation') || !$plugin->isActivated('reservation')
     return http_response_code(401);
 }
 
-if (!Session::haveRightsOr("reservation", [CREATE, UPDATE, DELETE])) {
+
+// Check if the user is allowed to go here
+$config = new PluginReservationConfig();
+$read_make_access = $config->getConfigurationValue("read_make_access");
+$access = [CREATE, UPDATE, DELETE];
+    
+if($read_make_access) {
+    $access = [READ, ReservationItem::RESERVEANITEM, CREATE, UPDATE, DELETE, PURGE];
+}
+
+if (!Session::haveRightsOr("reservation", $access)) {
     return http_response_code(401);
 }
 

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -177,6 +177,16 @@ class PluginReservationConfig extends CommonDBTM
         echo "</td>";
         echo "</tr>";
 
+        // read and make access
+        $read_make_access = $this->getConfigurationValue("read_make_access", 0);
+        echo '<tr class="tab_bg_2">';
+        echo "<input type=\"hidden\" name=\"read_make_access\" value=\"0\">";
+        echo "<td style=\"padding-left:20px;\">";
+        echo "<input type=\"checkbox\" name=\"read_make_access\" value=\"1\" " . ($read_make_access ? 'checked' : '') . "> ";
+        echo __('Enable access for users with Read and Make a reservation right', 'reservation') . "</td>";
+        echo '</tr>';
+
+
         // checkin
         $checkin = $this->getConfigurationValue("checkin", 0);
         $checkin_timeout = $this->getConfigurationValue("checkin_timeout", 1);

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -185,7 +185,17 @@ class PluginReservationConfig extends CommonDBTM
         echo "<input type=\"checkbox\" name=\"read_make_access\" value=\"1\" " . ($read_make_access ? 'checked' : '') . "> ";
         echo __('Enable access for users with Read and Make a reservation right', 'reservation') . "</td>";
         echo '</tr>';
-
+        
+        $only_ckeckin_own = $this->getConfigurationValue("only_ckeckin_own", 1);
+        if ($read_make_access){
+            // only checkin own reservation (by pass for admins)
+            echo '<tr class="tab_bg_2">';
+            echo "<input type=\"hidden\" name=\"only_ckeckin_own\" value=\"0\">";
+            echo "<td style=\"padding-left:20px;\">";
+            echo "<input type=\"checkbox\" name=\"only_ckeckin_own\" value=\"1\" " . ($only_ckeckin_own ? 'checked' : '') . "> ";
+            echo __('Users can only checkin/out and edit their own reservations (bypass for admins with delete rights)', 'reservation') . "</td>";
+            echo '</tr>';
+        }
 
         // checkin
         $checkin = $this->getConfigurationValue("checkin", 0);


### PR DESCRIPTION
This PR will add an option to allow or prevent users from editing/checking in/out on reservation that do not belong to them.

Administrators (with delete rights) can still edit/check in/out everyone's reservations.

This PR is an extension of #94 than can allow access to the plugin to more users